### PR TITLE
Make `spi-flash` `no-std` compatible (still requires `alloc`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Make `spi-flash` `no-std` compatible (still requires `alloc`)
+
 ## [v0.2.2] - 2021-01-20
 
 * Fix reading v1.0 SFDP table.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ description = "SPI flash memory interface crate"
 
 [dependencies]
 log = "0.4.11"
-anyhow = "1.0.34"
-thiserror = "1.0.22"
 num_enum = "0.5.1"
 jep106 = "0.2.4"
-indicatif = "0.15.0"
+anyhow = { version="1.0.34", optional=true }
+thiserror = { version="1.0.22", optional=true }
+indicatif = { version="0.15.0", optional=true }
+
+[features]
+default = ["std"]
+std = ["thiserror", "anyhow", "indicatif"]

--- a/src/erase_plan.rs
+++ b/src/erase_plan.rs
@@ -30,14 +30,8 @@ impl ErasePlan {
                 if erase_end > end {
                     bytes -= erase_end - end + 1;
                 }
-                log::trace!(
-                    "  Candidate 0x{:02X} ({} bytes): base={} end={} bytes={}",
-                    opcode,
-                    erase_size,
-                    erase_base,
-                    erase_end,
-                    bytes
-                );
+                log::trace!("  Candidate 0x{:02X} ({} bytes): base={} end={} bytes={}",
+                            opcode, erase_size, erase_base, erase_end, bytes);
                 if bytes > candidate.0 || (bytes == candidate.0 && *erase_size < candidate.1) {
                     candidate = (bytes, *erase_size, *opcode, erase_base, *duration);
                 }
@@ -63,23 +57,24 @@ impl ErasePlan {
 fn test_erase_plan() {
     let insts = &[(4, 1, None), (32, 2, None), (64, 3, None)];
     // Use a single 4kB erase to erase an aligned 4kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 4).0, alloc::vec![(1, 4, 0, None)]);
+    assert_eq!(ErasePlan::new(insts, 0, 4).0,
+               alloc::vec![(1, 4, 0, None)]);
     // Use a single 64kB erase to erase an aligned 64kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 64).0, alloc::vec![(3, 64, 0, None)]);
+    assert_eq!(ErasePlan::new(insts, 0, 64).0,
+               alloc::vec![(3, 64, 0, None)]);
     // Use three 64kB erases to erase an aligned 192kB block.
-    assert_eq!(
-        ErasePlan::new(insts, 0, 192).0,
-        alloc::vec![(3, 64, 0, None), (3, 64, 64, None), (3, 64, 128, None)]
-    );
+    assert_eq!(ErasePlan::new(insts, 0, 192).0,
+               alloc::vec![(3, 64, 0, None), (3, 64, 64, None), (3, 64, 128, None)]);
     // Use 64kB followed by 32kB to erase an aligned 70kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 70).0, alloc::vec![(3, 64, 0, None), (2, 32, 64, None)]);
+    assert_eq!(ErasePlan::new(insts, 0, 70).0,
+               alloc::vec![(3, 64, 0, None), (2, 32, 64, None)]);
     // Use 64kB followed by 4kB to erase an aligned 66kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 66).0, alloc::vec![(3, 64, 0, None), (1, 4, 64, None)]);
+    assert_eq!(ErasePlan::new(insts, 0, 66).0,
+               alloc::vec![(3, 64, 0, None), (1, 4, 64, None)]);
     // Use 4kB followed by 64kB to erase a misaligned 64kB block.
-    assert_eq!(ErasePlan::new(insts, 62, 64).0, alloc::vec![(1, 4, 60, None), (3, 64, 64, None)]);
+    assert_eq!(ErasePlan::new(insts, 62, 64).0,
+               alloc::vec![(1, 4, 60, None), (3, 64, 64, None)]);
     // Use a 4kB, 64kB, 4kB to erase a misaligned 68kB block.
-    assert_eq!(
-        ErasePlan::new(insts, 62, 68).0,
-        alloc::vec![(1, 4, 60, None), (3, 64, 64, None), (1, 4, 128, None)]
-    );
+    assert_eq!(ErasePlan::new(insts, 62, 68).0,
+               alloc::vec![(1, 4, 60, None), (3, 64, 64, None), (1, 4, 128, None)]);
 }

--- a/src/erase_plan.rs
+++ b/src/erase_plan.rs
@@ -53,7 +53,7 @@ impl ErasePlan {
         ErasePlan(plan)
     }
 
-    #[allow(dead_code)]
+    #[cfg(feature = "std")]
     pub fn total_size(&self) -> usize {
         self.0.iter().map(|x| x.1).sum()
     }

--- a/src/erase_plan.rs
+++ b/src/erase_plan.rs
@@ -1,4 +1,5 @@
-use std::time::Duration;
+use alloc::vec::Vec;
+use core::time::Duration;
 
 /// Erase plan of (opcode, size, base address, typical duration) to erase a range of memory.
 #[derive(Clone, Debug)]
@@ -29,8 +30,14 @@ impl ErasePlan {
                 if erase_end > end {
                     bytes -= erase_end - end + 1;
                 }
-                log::trace!("  Candidate 0x{:02X} ({} bytes): base={} end={} bytes={}",
-                            opcode, erase_size, erase_base, erase_end, bytes);
+                log::trace!(
+                    "  Candidate 0x{:02X} ({} bytes): base={} end={} bytes={}",
+                    opcode,
+                    erase_size,
+                    erase_base,
+                    erase_end,
+                    bytes
+                );
                 if bytes > candidate.0 || (bytes == candidate.0 && *erase_size < candidate.1) {
                     candidate = (bytes, *erase_size, *opcode, erase_base, *duration);
                 }
@@ -46,6 +53,7 @@ impl ErasePlan {
         ErasePlan(plan)
     }
 
+    #[allow(dead_code)]
     pub fn total_size(&self) -> usize {
         self.0.iter().map(|x| x.1).sum()
     }
@@ -55,24 +63,23 @@ impl ErasePlan {
 fn test_erase_plan() {
     let insts = &[(4, 1, None), (32, 2, None), (64, 3, None)];
     // Use a single 4kB erase to erase an aligned 4kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 4).0,
-               vec![(1, 4, 0, None)]);
+    assert_eq!(ErasePlan::new(insts, 0, 4).0, alloc::vec![(1, 4, 0, None)]);
     // Use a single 64kB erase to erase an aligned 64kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 64).0,
-               vec![(3, 64, 0, None)]);
+    assert_eq!(ErasePlan::new(insts, 0, 64).0, alloc::vec![(3, 64, 0, None)]);
     // Use three 64kB erases to erase an aligned 192kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 192).0,
-               vec![(3, 64, 0, None), (3, 64, 64, None), (3, 64, 128, None)]);
+    assert_eq!(
+        ErasePlan::new(insts, 0, 192).0,
+        alloc::vec![(3, 64, 0, None), (3, 64, 64, None), (3, 64, 128, None)]
+    );
     // Use 64kB followed by 32kB to erase an aligned 70kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 70).0,
-               vec![(3, 64, 0, None), (2, 32, 64, None)]);
+    assert_eq!(ErasePlan::new(insts, 0, 70).0, alloc::vec![(3, 64, 0, None), (2, 32, 64, None)]);
     // Use 64kB followed by 4kB to erase an aligned 66kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 66).0,
-               vec![(3, 64, 0, None), (1, 4, 64, None)]);
+    assert_eq!(ErasePlan::new(insts, 0, 66).0, alloc::vec![(3, 64, 0, None), (1, 4, 64, None)]);
     // Use 4kB followed by 64kB to erase a misaligned 64kB block.
-    assert_eq!(ErasePlan::new(insts, 62, 64).0,
-               vec![(1, 4, 60, None), (3, 64, 64, None)]);
+    assert_eq!(ErasePlan::new(insts, 62, 64).0, alloc::vec![(1, 4, 60, None), (3, 64, 64, None)]);
     // Use a 4kB, 64kB, 4kB to erase a misaligned 68kB block.
-    assert_eq!(ErasePlan::new(insts, 62, 68).0,
-               vec![(1, 4, 60, None), (3, 64, 64, None), (1, 4, 128, None)]);
+    assert_eq!(
+        ErasePlan::new(insts, 62, 68).0,
+        alloc::vec![(1, 4, 60, None), (3, 64, 64, None), (1, 4, 128, None)]
+    );
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,3 +1,5 @@
+use crate::alloc::string::ToString;
+
 /// Store the ID read off an SPI flash memory.
 ///
 /// The manufacturer ID and (long, 16-bit) device ID are read using the 0x9F command,
@@ -29,18 +31,20 @@ impl FlashID {
     }
 }
 
-impl std::fmt::Display for FlashID {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for FlashID {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         let mfn = match self.manufacturer_name() {
-            Some(mfn) => format!(" ({})", mfn),
+            Some(mfn) => alloc::format!(" ({})", mfn),
             None => "".to_string(),
         };
         let unique_id = match self.unique_id {
             0x0000_0000_0000_0000 | 0xFFFF_FFFF_FFFF_FFFF => "".to_string(),
-            id => format!(", Unique ID: {:016X}", id),
+            id => alloc::format!(", Unique ID: {:016X}", id),
         };
-        write!(f, "Manufacturer 0x{:02X}{}, Device 0x{:02X}/0x{:04X}{}",
-               self.manufacturer_id, mfn, self.device_id_short,
-               self.device_id_long, unique_id)
+        write!(
+            f,
+            "Manufacturer 0x{:02X}{}, Device 0x{:02X}/0x{:04X}{}",
+            self.manufacturer_id, mfn, self.device_id_short, self.device_id_long, unique_id
+        )
     }
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -41,10 +41,8 @@ impl core::fmt::Display for FlashID {
             0x0000_0000_0000_0000 | 0xFFFF_FFFF_FFFF_FFFF => "".to_string(),
             id => alloc::format!(", Unique ID: {:016X}", id),
         };
-        write!(
-            f,
-            "Manufacturer 0x{:02X}{}, Device 0x{:02X}/0x{:04X}{}",
-            self.manufacturer_id, mfn, self.device_id_short, self.device_id_long, unique_id
-        )
+        write!(f, "Manufacturer 0x{:02X}{}, Device 0x{:02X}/0x{:04X}{}",
+               self.manufacturer_id, mfn, self.device_id_short,
+               self.device_id_long, unique_id)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,8 @@ pub trait FlashAccess {
     /// Returns the received data.
     fn exchange(&mut self, data: &[u8]) -> AnyhowResult<Vec<u8>>;
 
-    fn sleep(&mut self, dur: Duration);
+    /// Wait for at least `dur`
+    fn delay(&mut self, dur: Duration);
 }
 
 /// SPI Flash.
@@ -723,7 +724,7 @@ impl<'a, A: FlashAccess> Flash<'a, A> {
                 // otherwise we'll likely have waited long enough just due to round-trip delays.
                 // We always poll the status register at least once to check write completion.
                 if timing.page_prog_time_typ > Duration::from_millis(1) {
-                    self.access.sleep(timing.page_prog_time_typ / 2);
+                    self.access.delay(timing.page_prog_time_typ / 2);
                 }
             }
         }
@@ -1056,7 +1057,7 @@ impl<'a, A: FlashAccess> Flash<'a, A> {
             self.write_enable()?;
             self.write(*opcode, &addr)?;
             if let Some(duration) = duration {
-                self.access.sleep(*duration / 2);
+                self.access.delay(*duration / 2);
             }
             self.wait_while_busy()?;
             total_erased += size;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,10 +128,10 @@ pub struct Flash<'a, A: FlashAccess> {
 }
 
 impl<'a, A: FlashAccess> Flash<'a, A> {
-    #[allow(dead_code)]
+    #[cfg(feature = "std")]
     const DATA_PROGRESS_TPL: &'static str =
         " {msg} [{bar:40}] {bytes}/{total_bytes} ({bytes_per_sec}; {eta_precise})";
-    #[allow(dead_code)]
+    #[cfg(feature = "std")]
     const DATA_PROGRESS_CHARS: &'static str = "=> ";
 
     /// Create a new Flash instance using the given FlashAccess provider.

--- a/src/sfdp.rs
+++ b/src/sfdp.rs
@@ -25,11 +25,8 @@ impl SFDPHeader {
             let nph = data[6] as usize + 1;
             log::debug!("Read SFDP header, NPH={} MAJOR={} MINOR={}", nph, major, minor);
             if data.len() < (nph + 1) * 8 {
-                log::error!(
-                    "Did not read enough SFDP bytes: got {}, needed {}",
-                    data.len(),
-                    (nph + 1) * 8
-                );
+                log::error!("Did not read enough SFDP bytes: got {}, needed {}",
+                            data.len(), (nph + 1) * 8);
                 Err(Error::InvalidSFDPHeader)
             } else {
                 let params = data[8..].chunks(8).map(SFDPParameterHeader::from_bytes).collect();
@@ -56,15 +53,9 @@ impl SFDPParameterHeader {
         let major = data[2];
         let plen = data[3] as usize;
         let ptp = u32::from_be_bytes([0, data[6], data[5], data[4]]);
-        log::debug!(
-            "Read JEDEC parameter header, plen={} major={} minor={} \
+        log::debug!("Read JEDEC parameter header, plen={} major={} minor={} \
                      ID=0x{:04X} PTP=0x{:06X}",
-            plen,
-            major,
-            minor,
-            parameter_id,
-            ptp
-        );
+                    plen, major, minor, parameter_id, ptp);
         SFDPParameterHeader { plen, major, minor, parameter_id, ptp }
     }
 }
@@ -122,6 +113,7 @@ pub struct FlashParams {
     // Omitted: Suspend/Resume support and instructions.
 
     // Omitted: Deep powerdown support and instructions.
+
     /// If true, polling busy status via the flag status register is supported.
     /// Instruction 0x70 reads the flag register, where bit 7 is 0 if busy and 1 if ready.
     pub busy_poll_flag: Option<bool>,
@@ -130,6 +122,7 @@ pub struct FlashParams {
     pub busy_poll_status: Option<bool>,
 
     // Omitted: instructions for entering/exiting 4-byte address mode.
+
     /// If true, the device may be reset using instruction 0xF0.
     pub reset_inst_f0: Option<bool>,
     /// If true, the device may be reset using instruction 0x66 followed by 0x99.
@@ -159,7 +152,7 @@ impl SFDPAddressBytes {
             0b00 => SFDPAddressBytes::Three,
             0b01 => SFDPAddressBytes::ThreeOrFour,
             0b10 => SFDPAddressBytes::Four,
-            _ => SFDPAddressBytes::Reserved,
+            _    => SFDPAddressBytes::Reserved,
         }
     }
 }
@@ -254,9 +247,7 @@ pub struct SFDPTiming {
 ///
 /// `bits!(word, length, offset)` extracts `length` number of bits at offset `offset`.
 macro_rules! bits {
-    ($d:expr, $n:expr, $o:expr) => {
-        ($d & (((1 << $n) - 1) << $o)) >> $o
-    };
+    ($d:expr, $n:expr, $o:expr) => {($d & (((1 << $n) - 1) << $o)) >> $o}
 }
 
 impl FlashParams {
@@ -357,10 +348,7 @@ impl FlashParams {
             let opcode = bits!(dwords[7], 8, 8) as u8;
             if opcode != 0 {
                 erase_insts[0] = Some(SFDPEraseInst {
-                    opcode,
-                    size: 1 << erase_size_1,
-                    time_typ: None,
-                    time_max: None,
+                    opcode, size: 1 << erase_size_1, time_typ: None, time_max: None,
                 });
             }
         }
@@ -368,10 +356,7 @@ impl FlashParams {
             let opcode = bits!(dwords[7], 8, 24) as u8;
             if opcode != 0 {
                 erase_insts[1] = Some(SFDPEraseInst {
-                    opcode,
-                    size: 1 << erase_size_2,
-                    time_typ: None,
-                    time_max: None,
+                    opcode, size: 1 << erase_size_2, time_typ: None, time_max: None,
                 });
             }
         }
@@ -379,10 +364,7 @@ impl FlashParams {
             let opcode = bits!(dwords[8], 8, 8) as u8;
             if opcode != 0 {
                 erase_insts[2] = Some(SFDPEraseInst {
-                    opcode,
-                    size: 1 << erase_size_3,
-                    time_typ: None,
-                    time_max: None,
+                    opcode, size: 1 << erase_size_3, time_typ: None, time_max: None,
                 });
             }
         }
@@ -390,10 +372,7 @@ impl FlashParams {
             let opcode = bits!(dwords[8], 8, 24) as u8;
             if opcode != 0 {
                 erase_insts[3] = Some(SFDPEraseInst {
-                    opcode,
-                    size: 1 << erase_size_4,
-                    time_typ: None,
-                    time_max: None,
+                    opcode, size: 1 << erase_size_4, time_typ: None, time_max: None,
                 });
             }
         }
@@ -401,23 +380,12 @@ impl FlashParams {
         // Return a FlashParams with the legacy information set and further information
         // cleared, which can be filled in if additional DWORDs are available.
         FlashParams {
-            version_major: major,
-            version_minor: minor,
-            address_bytes,
-            density,
-            legacy_4kb_erase_supported,
-            legacy_4kb_erase_inst,
-            legacy_volatile_write_en_inst,
-            legacy_block_protect_volatile,
-            legacy_byte_write_granularity,
-            erase_insts,
-            timing: None,
-            page_size: None,
-            busy_poll_flag: None,
-            busy_poll_status: None,
-            reset_inst_f0: None,
-            reset_inst_66_99: None,
-            status_1_vol: None,
+            version_major: major, version_minor: minor,
+            address_bytes, density, legacy_4kb_erase_supported, legacy_4kb_erase_inst,
+            legacy_volatile_write_en_inst, legacy_block_protect_volatile,
+            legacy_byte_write_granularity, erase_insts,
+            timing: None, page_size: None, busy_poll_flag: None, busy_poll_status: None,
+            reset_inst_f0: None, reset_inst_66_99: None, status_1_vol: None,
         }
     }
 
@@ -465,14 +433,10 @@ impl FlashParams {
         let (page_prog_time_typ, page_prog_time_max) =
             Self::page_program_duration(typ, program_scale);
         self.timing = Some(SFDPTiming {
-            chip_erase_time_typ,
-            chip_erase_time_max,
-            succ_byte_prog_time_typ,
-            succ_byte_prog_time_max,
-            first_byte_prog_time_typ,
-            first_byte_prog_time_max,
-            page_prog_time_typ,
-            page_prog_time_max,
+            chip_erase_time_typ, chip_erase_time_max,
+            succ_byte_prog_time_typ, succ_byte_prog_time_max,
+            first_byte_prog_time_typ, first_byte_prog_time_max,
+            page_prog_time_typ, page_prog_time_max,
         });
         self.page_size = Some(1 << bits!(dwords[10], 4, 4));
 
@@ -502,7 +466,7 @@ impl FlashParams {
             0b01 => Duration::from_millis(16),
             0b10 => Duration::from_millis(128),
             0b11 => Duration::from_secs(1),
-            _ => unreachable!(),
+            _    => unreachable!(),
         };
         let count = bits!(typ, 5, 0);
         let typ = (count + 1) * scale;
@@ -519,7 +483,7 @@ impl FlashParams {
             0b01 => Duration::from_millis(256),
             0b10 => Duration::from_secs(4),
             0b11 => Duration::from_secs(64),
-            _ => unreachable!(),
+            _    => unreachable!(),
         };
         let count = bits!(typ, 5, 0);
         let typ = (count + 1) * scale;
@@ -534,7 +498,7 @@ impl FlashParams {
         let scale = match bits!(typ, 1, 4) {
             0b0 => Duration::from_micros(1),
             0b1 => Duration::from_micros(8),
-            _ => unreachable!(),
+            _    => unreachable!(),
         };
         let count = bits!(typ, 4, 0);
         let typ = (count + 1) * scale;
@@ -549,7 +513,7 @@ impl FlashParams {
         let scale = match bits!(typ, 1, 5) {
             0b0 => Duration::from_micros(8),
             0b1 => Duration::from_micros(64),
-            _ => unreachable!(),
+            _    => unreachable!(),
         };
         let count = bits!(typ, 5, 0);
         let typ = (count + 1) * scale;
@@ -560,53 +524,34 @@ impl FlashParams {
 
 impl core::fmt::Display for FlashParams {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        writeln!(
-            f,
-            "SFDP JEDEC Basic Flash Parameter Table v{}.{}",
-            self.version_major, self.version_minor
-        )?;
+        writeln!(f, "SFDP JEDEC Basic Flash Parameter Table v{}.{}",
+               self.version_major, self.version_minor)?;
         writeln!(f, "  Density: {} bits ({} KiB)", self.density, self.capacity_bytes() / 1024)?;
         writeln!(f, "  Address bytes: {:?}", self.address_bytes)?;
         writeln!(f, "  Legacy information:")?;
         writeln!(f, "    4kB erase supported: {}", self.legacy_4kb_erase_supported)?;
         writeln!(f, "    4kB erase opcode: 0x{:02X}", self.legacy_4kb_erase_inst)?;
         writeln!(f, "    Block Protect always volatile: {}", self.legacy_block_protect_volatile)?;
-        writeln!(
-            f,
-            "    Volatile write enable opcode: 0x{:02X}",
-            self.legacy_volatile_write_en_inst
-        )?;
+        writeln!(f, "    Volatile write enable opcode: 0x{:02X}", self.legacy_volatile_write_en_inst)?;
         writeln!(f, "    Writes have byte granularity: {}", self.legacy_byte_write_granularity)?;
         writeln!(f, "  Erase instructions:")?;
         for i in 0..4 {
             if let Some(inst) = self.erase_insts[i] {
-                writeln!(f, "    {}: {}", i + 1, inst)?;
+                writeln!(f, "    {}: {}", i+1, inst)?;
             } else {
-                writeln!(f, "    {}: Not present", i + 1)?;
+                writeln!(f, "    {}: Not present", i+1)?;
             }
         }
         if let Some(timing) = self.timing {
             writeln!(f, "  Timing:")?;
-            writeln!(
-                f,
-                "    Chip erase: typ {:?}, max {:?}",
-                timing.chip_erase_time_typ, timing.chip_erase_time_max
-            )?;
-            writeln!(
-                f,
-                "    First byte program: typ {:?}, max {:?}",
-                timing.first_byte_prog_time_typ, timing.first_byte_prog_time_max
-            )?;
-            writeln!(
-                f,
-                "    Subsequent byte program: typ {:?}, max {:?}",
-                timing.succ_byte_prog_time_typ, timing.succ_byte_prog_time_max
-            )?;
-            writeln!(
-                f,
-                "    Page program: typ {:?}, max {:?}",
-                timing.page_prog_time_typ, timing.page_prog_time_max
-            )?;
+            writeln!(f, "    Chip erase: typ {:?}, max {:?}",
+                     timing.chip_erase_time_typ, timing.chip_erase_time_max)?;
+            writeln!(f, "    First byte program: typ {:?}, max {:?}",
+                     timing.first_byte_prog_time_typ, timing.first_byte_prog_time_max)?;
+            writeln!(f, "    Subsequent byte program: typ {:?}, max {:?}",
+                     timing.succ_byte_prog_time_typ, timing.succ_byte_prog_time_max)?;
+            writeln!(f, "    Page program: typ {:?}, max {:?}",
+                     timing.page_prog_time_typ, timing.page_prog_time_max)?;
         }
         if let Some(page_size) = self.page_size {
             writeln!(f, "  Page size: {} bytes", page_size)?;

--- a/src/sfdp.rs
+++ b/src/sfdp.rs
@@ -1,5 +1,6 @@
-use std::time::Duration;
 use crate::{Error, Result};
+use alloc::vec::Vec;
+use core::time::Duration;
 
 #[derive(Clone, Debug)]
 pub(crate) struct SFDPHeader {
@@ -24,8 +25,11 @@ impl SFDPHeader {
             let nph = data[6] as usize + 1;
             log::debug!("Read SFDP header, NPH={} MAJOR={} MINOR={}", nph, major, minor);
             if data.len() < (nph + 1) * 8 {
-                log::error!("Did not read enough SFDP bytes: got {}, needed {}",
-                            data.len(), (nph + 1) * 8);
+                log::error!(
+                    "Did not read enough SFDP bytes: got {}, needed {}",
+                    data.len(),
+                    (nph + 1) * 8
+                );
                 Err(Error::InvalidSFDPHeader)
             } else {
                 let params = data[8..].chunks(8).map(SFDPParameterHeader::from_bytes).collect();
@@ -52,9 +56,15 @@ impl SFDPParameterHeader {
         let major = data[2];
         let plen = data[3] as usize;
         let ptp = u32::from_be_bytes([0, data[6], data[5], data[4]]);
-        log::debug!("Read JEDEC parameter header, plen={} major={} minor={} \
+        log::debug!(
+            "Read JEDEC parameter header, plen={} major={} minor={} \
                      ID=0x{:04X} PTP=0x{:06X}",
-                    plen, major, minor, parameter_id, ptp);
+            plen,
+            major,
+            minor,
+            parameter_id,
+            ptp
+        );
         SFDPParameterHeader { plen, major, minor, parameter_id, ptp }
     }
 }
@@ -112,7 +122,6 @@ pub struct FlashParams {
     // Omitted: Suspend/Resume support and instructions.
 
     // Omitted: Deep powerdown support and instructions.
-
     /// If true, polling busy status via the flag status register is supported.
     /// Instruction 0x70 reads the flag register, where bit 7 is 0 if busy and 1 if ready.
     pub busy_poll_flag: Option<bool>,
@@ -121,7 +130,6 @@ pub struct FlashParams {
     pub busy_poll_status: Option<bool>,
 
     // Omitted: instructions for entering/exiting 4-byte address mode.
-
     /// If true, the device may be reset using instruction 0xF0.
     pub reset_inst_f0: Option<bool>,
     /// If true, the device may be reset using instruction 0x66 followed by 0x99.
@@ -151,7 +159,7 @@ impl SFDPAddressBytes {
             0b00 => SFDPAddressBytes::Three,
             0b01 => SFDPAddressBytes::ThreeOrFour,
             0b10 => SFDPAddressBytes::Four,
-            _    => SFDPAddressBytes::Reserved,
+            _ => SFDPAddressBytes::Reserved,
         }
     }
 }
@@ -164,13 +172,13 @@ pub struct SFDPEraseInst {
     /// Size in bytes of erase instruction.
     pub size: u32,
     /// Typical erase time, if known.
-    pub time_typ: Option<std::time::Duration>,
+    pub time_typ: Option<Duration>,
     /// Maximum erase time, if known.
-    pub time_max: Option<std::time::Duration>,
+    pub time_max: Option<Duration>,
 }
 
-impl std::fmt::Display for SFDPEraseInst {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for SFDPEraseInst {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "Opcode 0x{:02X}: {} bytes", self.opcode, self.size)?;
         if let Some(typ) = self.time_typ {
             write!(f, ", typ {:?}", typ)?;
@@ -246,7 +254,9 @@ pub struct SFDPTiming {
 ///
 /// `bits!(word, length, offset)` extracts `length` number of bits at offset `offset`.
 macro_rules! bits {
-    ($d:expr, $n:expr, $o:expr) => {($d & (((1 << $n) - 1) << $o)) >> $o}
+    ($d:expr, $n:expr, $o:expr) => {
+        ($d & (((1 << $n) - 1) << $o)) >> $o
+    };
 }
 
 impl FlashParams {
@@ -347,7 +357,10 @@ impl FlashParams {
             let opcode = bits!(dwords[7], 8, 8) as u8;
             if opcode != 0 {
                 erase_insts[0] = Some(SFDPEraseInst {
-                    opcode, size: 1 << erase_size_1, time_typ: None, time_max: None,
+                    opcode,
+                    size: 1 << erase_size_1,
+                    time_typ: None,
+                    time_max: None,
                 });
             }
         }
@@ -355,7 +368,10 @@ impl FlashParams {
             let opcode = bits!(dwords[7], 8, 24) as u8;
             if opcode != 0 {
                 erase_insts[1] = Some(SFDPEraseInst {
-                    opcode, size: 1 << erase_size_2, time_typ: None, time_max: None,
+                    opcode,
+                    size: 1 << erase_size_2,
+                    time_typ: None,
+                    time_max: None,
                 });
             }
         }
@@ -363,7 +379,10 @@ impl FlashParams {
             let opcode = bits!(dwords[8], 8, 8) as u8;
             if opcode != 0 {
                 erase_insts[2] = Some(SFDPEraseInst {
-                    opcode, size: 1 << erase_size_3, time_typ: None, time_max: None,
+                    opcode,
+                    size: 1 << erase_size_3,
+                    time_typ: None,
+                    time_max: None,
                 });
             }
         }
@@ -371,7 +390,10 @@ impl FlashParams {
             let opcode = bits!(dwords[8], 8, 24) as u8;
             if opcode != 0 {
                 erase_insts[3] = Some(SFDPEraseInst {
-                    opcode, size: 1 << erase_size_4, time_typ: None, time_max: None,
+                    opcode,
+                    size: 1 << erase_size_4,
+                    time_typ: None,
+                    time_max: None,
                 });
             }
         }
@@ -379,12 +401,23 @@ impl FlashParams {
         // Return a FlashParams with the legacy information set and further information
         // cleared, which can be filled in if additional DWORDs are available.
         FlashParams {
-            version_major: major, version_minor: minor,
-            address_bytes, density, legacy_4kb_erase_supported, legacy_4kb_erase_inst,
-            legacy_volatile_write_en_inst, legacy_block_protect_volatile,
-            legacy_byte_write_granularity, erase_insts,
-            timing: None, page_size: None, busy_poll_flag: None, busy_poll_status: None,
-            reset_inst_f0: None, reset_inst_66_99: None, status_1_vol: None,
+            version_major: major,
+            version_minor: minor,
+            address_bytes,
+            density,
+            legacy_4kb_erase_supported,
+            legacy_4kb_erase_inst,
+            legacy_volatile_write_en_inst,
+            legacy_block_protect_volatile,
+            legacy_byte_write_granularity,
+            erase_insts,
+            timing: None,
+            page_size: None,
+            busy_poll_flag: None,
+            busy_poll_status: None,
+            reset_inst_f0: None,
+            reset_inst_66_99: None,
+            status_1_vol: None,
         }
     }
 
@@ -432,10 +465,14 @@ impl FlashParams {
         let (page_prog_time_typ, page_prog_time_max) =
             Self::page_program_duration(typ, program_scale);
         self.timing = Some(SFDPTiming {
-            chip_erase_time_typ, chip_erase_time_max,
-            succ_byte_prog_time_typ, succ_byte_prog_time_max,
-            first_byte_prog_time_typ, first_byte_prog_time_max,
-            page_prog_time_typ, page_prog_time_max,
+            chip_erase_time_typ,
+            chip_erase_time_max,
+            succ_byte_prog_time_typ,
+            succ_byte_prog_time_max,
+            first_byte_prog_time_typ,
+            first_byte_prog_time_max,
+            page_prog_time_typ,
+            page_prog_time_max,
         });
         self.page_size = Some(1 << bits!(dwords[10], 4, 4));
 
@@ -465,7 +502,7 @@ impl FlashParams {
             0b01 => Duration::from_millis(16),
             0b10 => Duration::from_millis(128),
             0b11 => Duration::from_secs(1),
-            _    => unreachable!(),
+            _ => unreachable!(),
         };
         let count = bits!(typ, 5, 0);
         let typ = (count + 1) * scale;
@@ -482,7 +519,7 @@ impl FlashParams {
             0b01 => Duration::from_millis(256),
             0b10 => Duration::from_secs(4),
             0b11 => Duration::from_secs(64),
-            _    => unreachable!(),
+            _ => unreachable!(),
         };
         let count = bits!(typ, 5, 0);
         let typ = (count + 1) * scale;
@@ -497,7 +534,7 @@ impl FlashParams {
         let scale = match bits!(typ, 1, 4) {
             0b0 => Duration::from_micros(1),
             0b1 => Duration::from_micros(8),
-            _    => unreachable!(),
+            _ => unreachable!(),
         };
         let count = bits!(typ, 4, 0);
         let typ = (count + 1) * scale;
@@ -512,7 +549,7 @@ impl FlashParams {
         let scale = match bits!(typ, 1, 5) {
             0b0 => Duration::from_micros(8),
             0b1 => Duration::from_micros(64),
-            _    => unreachable!(),
+            _ => unreachable!(),
         };
         let count = bits!(typ, 5, 0);
         let typ = (count + 1) * scale;
@@ -521,36 +558,55 @@ impl FlashParams {
     }
 }
 
-impl std::fmt::Display for FlashParams {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        writeln!(f, "SFDP JEDEC Basic Flash Parameter Table v{}.{}",
-               self.version_major, self.version_minor)?;
+impl core::fmt::Display for FlashParams {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        writeln!(
+            f,
+            "SFDP JEDEC Basic Flash Parameter Table v{}.{}",
+            self.version_major, self.version_minor
+        )?;
         writeln!(f, "  Density: {} bits ({} KiB)", self.density, self.capacity_bytes() / 1024)?;
         writeln!(f, "  Address bytes: {:?}", self.address_bytes)?;
         writeln!(f, "  Legacy information:")?;
         writeln!(f, "    4kB erase supported: {}", self.legacy_4kb_erase_supported)?;
         writeln!(f, "    4kB erase opcode: 0x{:02X}", self.legacy_4kb_erase_inst)?;
         writeln!(f, "    Block Protect always volatile: {}", self.legacy_block_protect_volatile)?;
-        writeln!(f, "    Volatile write enable opcode: 0x{:02X}", self.legacy_volatile_write_en_inst)?;
+        writeln!(
+            f,
+            "    Volatile write enable opcode: 0x{:02X}",
+            self.legacy_volatile_write_en_inst
+        )?;
         writeln!(f, "    Writes have byte granularity: {}", self.legacy_byte_write_granularity)?;
         writeln!(f, "  Erase instructions:")?;
         for i in 0..4 {
             if let Some(inst) = self.erase_insts[i] {
-                writeln!(f, "    {}: {}", i+1, inst)?;
+                writeln!(f, "    {}: {}", i + 1, inst)?;
             } else {
-                writeln!(f, "    {}: Not present", i+1)?;
+                writeln!(f, "    {}: Not present", i + 1)?;
             }
         }
         if let Some(timing) = self.timing {
             writeln!(f, "  Timing:")?;
-            writeln!(f, "    Chip erase: typ {:?}, max {:?}",
-                     timing.chip_erase_time_typ, timing.chip_erase_time_max)?;
-            writeln!(f, "    First byte program: typ {:?}, max {:?}",
-                     timing.first_byte_prog_time_typ, timing.first_byte_prog_time_max)?;
-            writeln!(f, "    Subsequent byte program: typ {:?}, max {:?}",
-                     timing.succ_byte_prog_time_typ, timing.succ_byte_prog_time_max)?;
-            writeln!(f, "    Page program: typ {:?}, max {:?}",
-                     timing.page_prog_time_typ, timing.page_prog_time_max)?;
+            writeln!(
+                f,
+                "    Chip erase: typ {:?}, max {:?}",
+                timing.chip_erase_time_typ, timing.chip_erase_time_max
+            )?;
+            writeln!(
+                f,
+                "    First byte program: typ {:?}, max {:?}",
+                timing.first_byte_prog_time_typ, timing.first_byte_prog_time_max
+            )?;
+            writeln!(
+                f,
+                "    Subsequent byte program: typ {:?}, max {:?}",
+                timing.succ_byte_prog_time_typ, timing.succ_byte_prog_time_max
+            )?;
+            writeln!(
+                f,
+                "    Page program: typ {:?}, max {:?}",
+                timing.page_prog_time_typ, timing.page_prog_time_max
+            )?;
         }
         if let Some(page_size) = self.page_size {
             writeln!(f, "  Page size: {} bytes", page_size)?;
@@ -573,4 +629,3 @@ impl std::fmt::Display for FlashParams {
         Ok(())
     }
 }
-


### PR DESCRIPTION
Fixes #2 

This PR adds `no-std` support.

PS:
- I tried to minimize reformatting, but I could not find rustfmt settings which resulted in the same formatting.
- To remove the dependency on `alloc` a major redesign would be necessary.
If you are interested I would try to do it.