### PR TITLE
Combine error definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 * Make `spi-flash` `no-std` compatible (still requires `alloc`)
+* `FlashAccess` trait methods now return custom `Result` instead of
+  `anyhow::Result`; implementors should usually return
+  `spi_flash::Error::Access` wrapping their own error.
 
 ## [v0.2.2] - 2021-01-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## [Unreleased]
 
-* Make `spi-flash` `no-std` compatible (still requires `alloc`)
-* `FlashAccess` trait methods now return custom `Result` instead of
-  `anyhow::Result`; implementors should usually return
-  `spi_flash::Error::Access` wrapping their own error.
+* Make `spi-flash` `no-std` compatible (still requires `alloc`).
+* The `FlashAccess` trait now has an associated `Error` type and its methods
+  return corresponding `Result`s; `From<FlashAccess::Error>` must now be
+  implemented for `spi_flash::Error`.
 
 ## [v0.2.2] - 2021-01-20
 


### PR DESCRIPTION
@Sympatron It looks like we can merge the error types with a slight change to the trait so that it has an associated type instead. I've tested this with `ecpdap` and `spidap` and it's easy to adjust to.

I also added a default impl of `delay`, since it doesn't matter if it's a no-op and this way it's easier for std-using dependents.