### PR TITLE
Remove dependency on `Duration` by replacing it with `u32` ms

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+reorder_imports = false
+reorder_modules = false
+use_small_heuristics = "Max"

--- a/src/erase_plan.rs
+++ b/src/erase_plan.rs
@@ -1,12 +1,11 @@
 use alloc::vec::Vec;
-use core::time::Duration;
 
 /// Erase plan of (opcode, size, base address, typical duration) to erase a range of memory.
 #[derive(Clone, Debug)]
-pub(crate) struct ErasePlan(pub Vec<(u8, usize, u32, Option<Duration>)>);
+pub(crate) struct ErasePlan(pub Vec<(u8, usize, u32, Option<u32>)>);
 
 impl ErasePlan {
-    pub fn new(insts: &[(usize, u8, Option<Duration>)], start: usize, length: usize) -> Self {
+    pub fn new(insts: &[(usize, u8, Option<u32>)], start: usize, length: usize) -> Self {
         log::trace!("Creating erase plan, start={} length={}", start, length);
         let mut plan = Vec::new();
 

--- a/src/erase_plan.rs
+++ b/src/erase_plan.rs
@@ -30,8 +30,14 @@ impl ErasePlan {
                 if erase_end > end {
                     bytes -= erase_end - end + 1;
                 }
-                log::trace!("  Candidate 0x{:02X} ({} bytes): base={} end={} bytes={}",
-                            opcode, erase_size, erase_base, erase_end, bytes);
+                log::trace!(
+                    "  Candidate 0x{:02X} ({} bytes): base={} end={} bytes={}",
+                    opcode,
+                    erase_size,
+                    erase_base,
+                    erase_end,
+                    bytes
+                );
                 if bytes > candidate.0 || (bytes == candidate.0 && *erase_size < candidate.1) {
                     candidate = (bytes, *erase_size, *opcode, erase_base, *duration);
                 }
@@ -57,24 +63,23 @@ impl ErasePlan {
 fn test_erase_plan() {
     let insts = &[(4, 1, None), (32, 2, None), (64, 3, None)];
     // Use a single 4kB erase to erase an aligned 4kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 4).0,
-               alloc::vec![(1, 4, 0, None)]);
+    assert_eq!(ErasePlan::new(insts, 0, 4).0, alloc::vec![(1, 4, 0, None)]);
     // Use a single 64kB erase to erase an aligned 64kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 64).0,
-               alloc::vec![(3, 64, 0, None)]);
+    assert_eq!(ErasePlan::new(insts, 0, 64).0, alloc::vec![(3, 64, 0, None)]);
     // Use three 64kB erases to erase an aligned 192kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 192).0,
-               alloc::vec![(3, 64, 0, None), (3, 64, 64, None), (3, 64, 128, None)]);
+    assert_eq!(
+        ErasePlan::new(insts, 0, 192).0,
+        alloc::vec![(3, 64, 0, None), (3, 64, 64, None), (3, 64, 128, None)]
+    );
     // Use 64kB followed by 32kB to erase an aligned 70kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 70).0,
-               alloc::vec![(3, 64, 0, None), (2, 32, 64, None)]);
+    assert_eq!(ErasePlan::new(insts, 0, 70).0, alloc::vec![(3, 64, 0, None), (2, 32, 64, None)]);
     // Use 64kB followed by 4kB to erase an aligned 66kB block.
-    assert_eq!(ErasePlan::new(insts, 0, 66).0,
-               alloc::vec![(3, 64, 0, None), (1, 4, 64, None)]);
+    assert_eq!(ErasePlan::new(insts, 0, 66).0, alloc::vec![(3, 64, 0, None), (1, 4, 64, None)]);
     // Use 4kB followed by 64kB to erase a misaligned 64kB block.
-    assert_eq!(ErasePlan::new(insts, 62, 64).0,
-               alloc::vec![(1, 4, 60, None), (3, 64, 64, None)]);
+    assert_eq!(ErasePlan::new(insts, 62, 64).0, alloc::vec![(1, 4, 60, None), (3, 64, 64, None)]);
     // Use a 4kB, 64kB, 4kB to erase a misaligned 68kB block.
-    assert_eq!(ErasePlan::new(insts, 62, 68).0,
-               alloc::vec![(1, 4, 60, None), (3, 64, 64, None), (1, 4, 128, None)]);
+    assert_eq!(
+        ErasePlan::new(insts, 62, 68).0,
+        alloc::vec![(1, 4, 60, None), (3, 64, 64, None), (1, 4, 128, None)]
+    );
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -41,8 +41,10 @@ impl core::fmt::Display for FlashID {
             0x0000_0000_0000_0000 | 0xFFFF_FFFF_FFFF_FFFF => "".to_string(),
             id => alloc::format!(", Unique ID: {:016X}", id),
         };
-        write!(f, "Manufacturer 0x{:02X}{}, Device 0x{:02X}/0x{:04X}{}",
-               self.manufacturer_id, mfn, self.device_id_short,
-               self.device_id_long, unique_id)
+        write!(
+            f,
+            "Manufacturer 0x{:02X}{}, Device 0x{:02X}/0x{:04X}{}",
+            self.manufacturer_id, mfn, self.device_id_short, self.device_id_long, unique_id
+        )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,24 +30,24 @@ pub use id::FlashID;
 use sfdp::SFDPHeader;
 use erase_plan::ErasePlan;
 
-#[cfg_attr(feature="std", derive(thiserror::Error, Debug))]
+#[cfg_attr(feature = "std", derive(thiserror::Error, Debug))]
 pub enum Error {
-    #[cfg_attr(feature="std", error("Mismatch during flash readback verification."))]
+    #[cfg_attr(feature = "std", error("Mismatch during flash readback verification."))]
     ReadbackError { address: u32, wrote: u8, read: u8 },
-    #[cfg_attr(feature="std", error("Invalid manufacturer ID detected."))]
+    #[cfg_attr(feature = "std", error("Invalid manufacturer ID detected."))]
     InvalidManufacturer,
-    #[cfg_attr(feature="std", error("Invalid SFDP header."))]
+    #[cfg_attr(feature = "std", error("Invalid SFDP header."))]
     InvalidSFDPHeader,
-    #[cfg_attr(feature="std", error("Invalid parameter in SFDP parameter table."))]
+    #[cfg_attr(feature = "std", error("Invalid parameter in SFDP parameter table."))]
     InvalidSFDPParams,
-    #[cfg_attr(feature="std", error("Address out of range for memory: 0x{address:08X}."))]
+    #[cfg_attr(feature = "std", error("Address out of range for memory: 0x{address:08X}."))]
     InvalidAddress { address: u32 },
-    #[cfg_attr(feature="std", error("No supported reset instruction is available."))]
+    #[cfg_attr(feature = "std", error("No supported reset instruction is available."))]
     NoResetInstruction,
-    #[cfg_attr(feature="std", error("No erase instruction has been specified."))]
+    #[cfg_attr(feature = "std", error("No erase instruction has been specified."))]
     NoEraseInstruction,
 
-    #[cfg(feature="std")]
+    #[cfg(feature = "std")]
     #[error(transparent)]
     Access(#[from] anyhow::Error),
 
@@ -133,7 +133,10 @@ pub struct Flash<'a, A: FlashAccess> {
     erase_opcode: u8,
 }
 
-impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Error> {
+impl<'a, A: FlashAccess> Flash<'a, A>
+where
+    Error: From<<A as FlashAccess>::Error>,
+{
     #[cfg(feature = "std")]
     const DATA_PROGRESS_TPL: &'static str =
         " {msg} [{bar:40}] {bytes}/{total_bytes} ({bytes_per_sec}; {eta_precise})";
@@ -273,7 +276,11 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
         }
 
         let id = FlashID {
-            manufacturer_bank, manufacturer_id, device_id_long, device_id_short, unique_id
+            manufacturer_bank,
+            manufacturer_id,
+            device_id_long,
+            device_id_short,
+            unique_id,
         };
 
         log::debug!("Read ID: {:?}", id);
@@ -307,7 +314,7 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
         // since not all flash devices support SFDP.
         // After this parse is successful, however, subsequent errors
         // are returned as errors.
-        let data = self.read_sfdp(0, 8 + nph*8)?;
+        let data = self.read_sfdp(0, 8 + nph * 8)?;
         let header = match SFDPHeader::from_bytes(&data) {
             Ok(header) => header,
             Err(_) => return Ok(None),
@@ -345,10 +352,13 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
             self.erase_opcode = params.legacy_4kb_erase_inst;
         }
         log::debug!("Updated settings from parameters:");
-        log::debug!("Address bytes: {}, capacity: {:?} bytes",
-                    self.address_bytes, self.capacity);
-        log::debug!("Page size: {:?}, erase size: {:?}, erase op: {}",
-                    self.page_size, self.erase_size, self.erase_opcode);
+        log::debug!("Address bytes: {}, capacity: {:?} bytes", self.address_bytes, self.capacity);
+        log::debug!(
+            "Page size: {:?}, erase size: {:?}, erase op: {}",
+            self.page_size,
+            self.erase_size,
+            self.erase_opcode
+        );
 
         Ok(Some(params))
     }
@@ -383,9 +393,7 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
     ///
     /// While `read()` performs a single long SPI exchange, this method performs
     /// up to 128 separate SPI exchanges to allow progress to be reported.
-    pub fn read_cb<F: Fn(usize)>(&mut self, address: u32, length: usize, cb: F)
-        -> Result<Vec<u8>>
-    {
+    pub fn read_cb<F: Fn(usize)>(&mut self, address: u32, length: usize, cb: F) -> Result<Vec<u8>> {
         self.check_address_length(address, length)?;
         let chunk_size = usize::max(1024, length / 128);
         let start = address as usize;
@@ -412,8 +420,11 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
     /// up to 128 separate SPI exchanges to allow progress to be reported.
     #[cfg(feature = "std")]
     pub fn read_progress(&mut self, address: u32, length: usize) -> Result<Vec<u8>> {
-        let pb = ProgressBar::new(length as u64).with_style(ProgressStyle::default_bar()
-            .template(Self::DATA_PROGRESS_TPL).progress_chars(Self::DATA_PROGRESS_CHARS));
+        let pb = ProgressBar::new(length as u64).with_style(
+            ProgressStyle::default_bar()
+                .template(Self::DATA_PROGRESS_TPL)
+                .progress_chars(Self::DATA_PROGRESS_CHARS),
+        );
         pb.set_message("Reading");
         let result = self.read_cb(address, length, |n| pb.set_position(n as u64));
         pb.finish();
@@ -445,9 +456,11 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
     pub fn erase_progress(&mut self) -> Result<()> {
         let time = self.params.map(|p| p.timing.map(|t| t.chip_erase_time_typ));
         let pb = if let Some(Some(time)) = time {
-            ProgressBar::new(time.as_millis() as u64).with_style(ProgressStyle::default_bar()
+            ProgressBar::new(time.as_millis() as u64).with_style(
+                ProgressStyle::default_bar()
                     .template(" {msg} [{bar:40}] {elapsed} < {eta}")
-            .progress_chars("=> "))
+                    .progress_chars("=> "),
+            )
         } else {
             ProgressBar::new_spinner()
         };
@@ -654,8 +667,11 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
     /// use `program()` for a higher-level erase-program-verify interface.
     #[cfg(feature = "std")]
     pub fn program_data_progress(&mut self, address: u32, data: &[u8]) -> Result<()> {
-        let pb = ProgressBar::new(data.len() as u64).with_style(ProgressStyle::default_bar()
-            .template(Self::DATA_PROGRESS_TPL).progress_chars(Self::DATA_PROGRESS_CHARS));
+        let pb = ProgressBar::new(data.len() as u64).with_style(
+            ProgressStyle::default_bar()
+                .template(Self::DATA_PROGRESS_TPL)
+                .progress_chars(Self::DATA_PROGRESS_CHARS),
+        );
         pb.set_message("Writing");
         self.program_data_cb(address, &data, |n| pb.set_position(n as u64))?;
         pb.finish();
@@ -669,9 +685,12 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
     ///
     /// Calls `cb` with the number of bytes programmed so far after each
     /// page programming operation.
-    pub fn program_data_cb<F: Fn(usize)>(&mut self, address: u32, mut data: &[u8], cb: F)
-        -> Result<()>
-    {
+    pub fn program_data_cb<F: Fn(usize)>(
+        &mut self,
+        address: u32,
+        mut data: &[u8],
+        cb: F,
+    ) -> Result<()> {
         let page_size = match self.page_size {
             Some(page_size) => page_size,
             None => {
@@ -755,7 +774,7 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
             let data = self.exchange(Command::ReadJEDECID, &[], 16)?;
             for n in 1..=13 {
                 if data[n] != 0x7F {
-                    return Ok((n as u8, data[n], u16::from_be_bytes([data[n+1], data[n+2]])));
+                    return Ok((n as u8, data[n], u16::from_be_bytes([data[n + 1], data[n + 2]])));
                 }
             }
             log::error!("Found more than 11 continuation bytes in manufacturer ID");
@@ -781,7 +800,7 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
             let data = self.exchange(Command::ReadJEDECID, &[0, 0, 0], 15)?;
             for n in 1..=13 {
                 if data[n] != 0x7F {
-                    return Ok((n as u8, data[n], data[n+1]))
+                    return Ok((n as u8, data[n], data[n + 1]));
                 }
             }
             log::error!("Found more than 11 continuation bytes in manufacturer ID");
@@ -831,10 +850,12 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
                 Some(SFDPStatus1Volatility::Volatile50) => 0x50,
                 Some(SFDPStatus1Volatility::NonVolatile06Volatile50) => 0x06,
                 Some(SFDPStatus1Volatility::Mixed06) => 0x06,
-                _ => if params.legacy_block_protect_volatile {
-                    params.legacy_volatile_write_en_inst
-                } else {
-                    Command::WriteEnable.into()
+                _ => {
+                    if params.legacy_block_protect_volatile {
+                        params.legacy_volatile_write_en_inst
+                    } else {
+                        Command::WriteEnable.into()
+                    }
                 }
             }
         } else {
@@ -893,21 +914,24 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
     /// `addr` is always sent as a 24-bit address, regardless of the address_bytes setting.
     pub fn read_sfdp(&mut self, addr: u32, len: usize) -> Result<Vec<u8>> {
         let bytes = addr.to_be_bytes();
-        self.exchange(Command::ReadSFDPRegister, &bytes[1..], 1+len)
+        self.exchange(Command::ReadSFDPRegister, &bytes[1..], 1 + len)
             .map(|data| data[1..].to_vec())
     }
 
     /// Writes `command` and `data` to the flash memory, then returns `nbytes` of response.
-    pub fn exchange<C: Into<u8>>(&mut self, command: C, data: &[u8], nbytes: usize)
-        -> Result<Vec<u8>>
-    {
+    pub fn exchange<C: Into<u8>>(
+        &mut self,
+        command: C,
+        data: &[u8],
+        nbytes: usize,
+    ) -> Result<Vec<u8>> {
         let mut tx = alloc::vec![command.into()];
         tx.extend(data);
         log::trace!("SPI exchange: write {:02X?}, read {} bytes", &tx, nbytes);
         tx.extend(alloc::vec![0u8; nbytes]);
         let rx = self.access.exchange(&tx)?;
-        log::trace!("SPI exchange: read {:02X?}", &rx[1+data.len()..]);
-        Ok(rx[1+data.len()..].to_vec())
+        log::trace!("SPI exchange: read {:02X?}", &rx[1 + data.len()..]);
+        Ok(rx[1 + data.len()..].to_vec())
     }
 
     /// Writes `command` and `data` to the flash memory, without reading the response.
@@ -947,7 +971,7 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
                 Some(capacity) if (end >= capacity) => {
                     log::error!("Operation would exceed flash capacity");
                     Err(Error::InvalidAddress { address: end as u32 })
-                },
+                }
                 _ => Ok(()),
             }
         }
@@ -1014,9 +1038,12 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
     ///
     /// If all those bytes are 0xFF, returns an empty Vec instead, as they won't be changed
     /// by the erase operation.
-    fn read_erase_postamble(&mut self, address: u32, length: usize, plan: &ErasePlan)
-        -> Result<Vec<u8>>
-    {
+    fn read_erase_postamble(
+        &mut self,
+        address: u32,
+        length: usize,
+        plan: &ErasePlan,
+    ) -> Result<Vec<u8>> {
         let (_, size, base, _) = plan.0.last().unwrap();
         let start = address + (length as u32);
         let len = (*base as usize + *size) - start as usize;
@@ -1036,9 +1063,12 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
 
     /// Extend `data` by adding any preamble and postamble required to preserve
     /// existing data after erasing and reprogramming.
-    fn make_restore_data(&mut self, address: u32, data: &[u8], erase_plan: &ErasePlan)
-        -> Result<Vec<u8>>
-    {
+    fn make_restore_data(
+        &mut self,
+        address: u32,
+        data: &[u8],
+        erase_plan: &ErasePlan,
+    ) -> Result<Vec<u8>> {
         let preamble = self.read_erase_preamble(address, &erase_plan)?;
         let postamble = self.read_erase_postamble(address, data.len(), &erase_plan)?;
         let mut full_data = preamble;
@@ -1054,8 +1084,12 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
         let mut total_erased = 0;
         cb(total_erased);
         for (opcode, size, base, duration) in plan.0.iter() {
-            log::trace!("Executing erase plan: Erase 0x{:02X} ({} bytes) from 0x{:08X}",
-                        opcode, size, base);
+            log::trace!(
+                "Executing erase plan: Erase 0x{:02X} ({} bytes) from 0x{:08X}",
+                opcode,
+                size,
+                base
+            );
             let addr = self.make_address(*base);
             self.write_enable()?;
             self.write(*opcode, &addr)?;
@@ -1075,8 +1109,11 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
     #[cfg(feature = "std")]
     fn run_erase_plan_progress(&mut self, plan: &ErasePlan) -> Result<()> {
         let erase_size = plan.total_size() as u64;
-        let pb = ProgressBar::new(erase_size).with_style(ProgressStyle::default_bar()
-            .template(Self::DATA_PROGRESS_TPL).progress_chars(Self::DATA_PROGRESS_CHARS));
+        let pb = ProgressBar::new(erase_size).with_style(
+            ProgressStyle::default_bar()
+                .template(Self::DATA_PROGRESS_TPL)
+                .progress_chars(Self::DATA_PROGRESS_CHARS),
+        );
         pb.set_message("Erasing");
         self.run_erase_plan(&plan, |n| pb.set_position(n as u64))?;
         pb.finish();
@@ -1091,13 +1128,17 @@ impl<'a, A: FlashAccess> Flash<'a, A> where Error: From<<A as FlashAccess>::Erro
         match mismatch {
             Some((idx, (a, b))) => {
                 let addr = address + idx as u32;
-                log::error!("Readback mismatch at 0x{:08X}: Wrote 0x{:02X}, read 0x{:02X}",
-                            addr, a, b);
+                log::error!(
+                    "Readback mismatch at 0x{:08X}: Wrote 0x{:02X}, read 0x{:02X}",
+                    addr,
+                    a,
+                    b
+                );
                 if self.is_protected()? {
                     log::error!("Flash write protection appears to be enabled, try unprotecting.");
                 }
                 Err(Error::ReadbackError { address: addr, wrote: *a, read: *b })
-            },
+            }
             None => Ok(()),
         }
     }

--- a/src/sfdp.rs
+++ b/src/sfdp.rs
@@ -25,8 +25,11 @@ impl SFDPHeader {
             let nph = data[6] as usize + 1;
             log::debug!("Read SFDP header, NPH={} MAJOR={} MINOR={}", nph, major, minor);
             if data.len() < (nph + 1) * 8 {
-                log::error!("Did not read enough SFDP bytes: got {}, needed {}",
-                            data.len(), (nph + 1) * 8);
+                log::error!(
+                    "Did not read enough SFDP bytes: got {}, needed {}",
+                    data.len(),
+                    (nph + 1) * 8
+                );
                 Err(Error::InvalidSFDPHeader)
             } else {
                 let params = data[8..].chunks(8).map(SFDPParameterHeader::from_bytes).collect();
@@ -53,9 +56,15 @@ impl SFDPParameterHeader {
         let major = data[2];
         let plen = data[3] as usize;
         let ptp = u32::from_be_bytes([0, data[6], data[5], data[4]]);
-        log::debug!("Read JEDEC parameter header, plen={} major={} minor={} \
+        log::debug!(
+            "Read JEDEC parameter header, plen={} major={} minor={} \
                      ID=0x{:04X} PTP=0x{:06X}",
-                    plen, major, minor, parameter_id, ptp);
+            plen,
+            major,
+            minor,
+            parameter_id,
+            ptp
+        );
         SFDPParameterHeader { plen, major, minor, parameter_id, ptp }
     }
 }
@@ -113,7 +122,6 @@ pub struct FlashParams {
     // Omitted: Suspend/Resume support and instructions.
 
     // Omitted: Deep powerdown support and instructions.
-
     /// If true, polling busy status via the flag status register is supported.
     /// Instruction 0x70 reads the flag register, where bit 7 is 0 if busy and 1 if ready.
     pub busy_poll_flag: Option<bool>,
@@ -122,7 +130,6 @@ pub struct FlashParams {
     pub busy_poll_status: Option<bool>,
 
     // Omitted: instructions for entering/exiting 4-byte address mode.
-
     /// If true, the device may be reset using instruction 0xF0.
     pub reset_inst_f0: Option<bool>,
     /// If true, the device may be reset using instruction 0x66 followed by 0x99.
@@ -152,7 +159,7 @@ impl SFDPAddressBytes {
             0b00 => SFDPAddressBytes::Three,
             0b01 => SFDPAddressBytes::ThreeOrFour,
             0b10 => SFDPAddressBytes::Four,
-            _    => SFDPAddressBytes::Reserved,
+            _ => SFDPAddressBytes::Reserved,
         }
     }
 }
@@ -247,7 +254,9 @@ pub struct SFDPTiming {
 ///
 /// `bits!(word, length, offset)` extracts `length` number of bits at offset `offset`.
 macro_rules! bits {
-    ($d:expr, $n:expr, $o:expr) => {($d & (((1 << $n) - 1) << $o)) >> $o}
+    ($d:expr, $n:expr, $o:expr) => {
+        ($d & (((1 << $n) - 1) << $o)) >> $o
+    };
 }
 
 impl FlashParams {
@@ -346,7 +355,10 @@ impl FlashParams {
             let opcode = bits!(dwords[7], 8, 8) as u8;
             if opcode != 0 {
                 erase_insts[0] = Some(SFDPEraseInst {
-                    opcode, size: 1 << erase_size_1, time_typ: None, time_max: None,
+                    opcode,
+                    size: 1 << erase_size_1,
+                    time_typ: None,
+                    time_max: None,
                 });
             }
         }
@@ -354,7 +366,10 @@ impl FlashParams {
             let opcode = bits!(dwords[7], 8, 24) as u8;
             if opcode != 0 {
                 erase_insts[1] = Some(SFDPEraseInst {
-                    opcode, size: 1 << erase_size_2, time_typ: None, time_max: None,
+                    opcode,
+                    size: 1 << erase_size_2,
+                    time_typ: None,
+                    time_max: None,
                 });
             }
         }
@@ -362,7 +377,10 @@ impl FlashParams {
             let opcode = bits!(dwords[8], 8, 8) as u8;
             if opcode != 0 {
                 erase_insts[2] = Some(SFDPEraseInst {
-                    opcode, size: 1 << erase_size_3, time_typ: None, time_max: None,
+                    opcode,
+                    size: 1 << erase_size_3,
+                    time_typ: None,
+                    time_max: None,
                 });
             }
         }
@@ -370,7 +388,10 @@ impl FlashParams {
             let opcode = bits!(dwords[8], 8, 24) as u8;
             if opcode != 0 {
                 erase_insts[3] = Some(SFDPEraseInst {
-                    opcode, size: 1 << erase_size_4, time_typ: None, time_max: None,
+                    opcode,
+                    size: 1 << erase_size_4,
+                    time_typ: None,
+                    time_max: None,
                 });
             }
         }
@@ -378,12 +399,23 @@ impl FlashParams {
         // Return a FlashParams with the legacy information set and further information
         // cleared, which can be filled in if additional DWORDs are available.
         FlashParams {
-            version_major: major, version_minor: minor,
-            address_bytes, density, legacy_4kb_erase_supported, legacy_4kb_erase_inst,
-            legacy_volatile_write_en_inst, legacy_block_protect_volatile,
-            legacy_byte_write_granularity, erase_insts,
-            timing: None, page_size: None, busy_poll_flag: None, busy_poll_status: None,
-            reset_inst_f0: None, reset_inst_66_99: None, status_1_vol: None,
+            version_major: major,
+            version_minor: minor,
+            address_bytes,
+            density,
+            legacy_4kb_erase_supported,
+            legacy_4kb_erase_inst,
+            legacy_volatile_write_en_inst,
+            legacy_block_protect_volatile,
+            legacy_byte_write_granularity,
+            erase_insts,
+            timing: None,
+            page_size: None,
+            busy_poll_flag: None,
+            busy_poll_status: None,
+            reset_inst_f0: None,
+            reset_inst_66_99: None,
+            status_1_vol: None,
         }
     }
 
@@ -431,10 +463,14 @@ impl FlashParams {
         let (page_prog_time_typ, page_prog_time_max) =
             Self::page_program_duration(typ, program_scale);
         self.timing = Some(SFDPTiming {
-            chip_erase_time_typ, chip_erase_time_max,
-            first_byte_prog_time_typ, first_byte_prog_time_max,
-            succ_byte_prog_time_typ, succ_byte_prog_time_max,
-            page_prog_time_typ, page_prog_time_max,
+            chip_erase_time_typ,
+            chip_erase_time_max,
+            first_byte_prog_time_typ,
+            first_byte_prog_time_max,
+            succ_byte_prog_time_typ,
+            succ_byte_prog_time_max,
+            page_prog_time_typ,
+            page_prog_time_max,
         });
         self.page_size = Some(1 << bits!(dwords[10], 4, 4));
 
@@ -464,7 +500,7 @@ impl FlashParams {
             0b01 => Duration::from_millis(16),
             0b10 => Duration::from_millis(128),
             0b11 => Duration::from_secs(1),
-            _    => unreachable!(),
+            _ => unreachable!(),
         };
         let count = bits!(typ, 5, 0);
         let typ = (count + 1) * scale;
@@ -481,7 +517,7 @@ impl FlashParams {
             0b01 => Duration::from_millis(256),
             0b10 => Duration::from_secs(4),
             0b11 => Duration::from_secs(64),
-            _    => unreachable!(),
+            _ => unreachable!(),
         };
         let count = bits!(typ, 5, 0);
         let typ = (count + 1) * scale;
@@ -496,7 +532,7 @@ impl FlashParams {
         let scale = match bits!(typ, 1, 4) {
             0b0 => Duration::from_micros(1),
             0b1 => Duration::from_micros(8),
-            _    => unreachable!(),
+            _ => unreachable!(),
         };
         let count = bits!(typ, 4, 0);
         let typ = (count + 1) * scale;
@@ -511,7 +547,7 @@ impl FlashParams {
         let scale = match bits!(typ, 1, 5) {
             0b0 => Duration::from_micros(8),
             0b1 => Duration::from_micros(64),
-            _    => unreachable!(),
+            _ => unreachable!(),
         };
         let count = bits!(typ, 5, 0);
         let typ = (count + 1) * scale;
@@ -522,34 +558,53 @@ impl FlashParams {
 
 impl core::fmt::Display for FlashParams {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        writeln!(f, "SFDP JEDEC Basic Flash Parameter Table v{}.{}",
-               self.version_major, self.version_minor)?;
+        writeln!(
+            f,
+            "SFDP JEDEC Basic Flash Parameter Table v{}.{}",
+            self.version_major, self.version_minor
+        )?;
         writeln!(f, "  Density: {} bits ({} KiB)", self.density, self.capacity_bytes() / 1024)?;
         writeln!(f, "  Address bytes: {:?}", self.address_bytes)?;
         writeln!(f, "  Legacy information:")?;
         writeln!(f, "    4kB erase supported: {}", self.legacy_4kb_erase_supported)?;
         writeln!(f, "    4kB erase opcode: 0x{:02X}", self.legacy_4kb_erase_inst)?;
         writeln!(f, "    Block Protect always volatile: {}", self.legacy_block_protect_volatile)?;
-        writeln!(f, "    Volatile write enable opcode: 0x{:02X}", self.legacy_volatile_write_en_inst)?;
+        writeln!(
+            f,
+            "    Volatile write enable opcode: 0x{:02X}",
+            self.legacy_volatile_write_en_inst
+        )?;
         writeln!(f, "    Writes have byte granularity: {}", self.legacy_byte_write_granularity)?;
         writeln!(f, "  Erase instructions:")?;
         for i in 0..4 {
             if let Some(inst) = self.erase_insts[i] {
-                writeln!(f, "    {}: {}", i+1, inst)?;
+                writeln!(f, "    {}: {}", i + 1, inst)?;
             } else {
-                writeln!(f, "    {}: Not present", i+1)?;
+                writeln!(f, "    {}: Not present", i + 1)?;
             }
         }
         if let Some(timing) = self.timing {
             writeln!(f, "  Timing:")?;
-            writeln!(f, "    Chip erase: typ {:?}, max {:?}",
-                     timing.chip_erase_time_typ, timing.chip_erase_time_max)?;
-            writeln!(f, "    First byte program: typ {:?}, max {:?}",
-                     timing.first_byte_prog_time_typ, timing.first_byte_prog_time_max)?;
-            writeln!(f, "    Subsequent byte program: typ {:?}, max {:?}",
-                     timing.succ_byte_prog_time_typ, timing.succ_byte_prog_time_max)?;
-            writeln!(f, "    Page program: typ {:?}, max {:?}",
-                     timing.page_prog_time_typ, timing.page_prog_time_max)?;
+            writeln!(
+                f,
+                "    Chip erase: typ {:?}, max {:?}",
+                timing.chip_erase_time_typ, timing.chip_erase_time_max
+            )?;
+            writeln!(
+                f,
+                "    First byte program: typ {:?}, max {:?}",
+                timing.first_byte_prog_time_typ, timing.first_byte_prog_time_max
+            )?;
+            writeln!(
+                f,
+                "    Subsequent byte program: typ {:?}, max {:?}",
+                timing.succ_byte_prog_time_typ, timing.succ_byte_prog_time_max
+            )?;
+            writeln!(
+                f,
+                "    Page program: typ {:?}, max {:?}",
+                timing.page_prog_time_typ, timing.page_prog_time_max
+            )?;
         }
         if let Some(page_size) = self.page_size {
             writeln!(f, "  Page size: {} bytes", page_size)?;

--- a/src/sreg.rs
+++ b/src/sreg.rs
@@ -69,4 +69,3 @@ impl StatusRegister3 {
         self.0 |= (wps as u8) << 2;
     }
 }
-


### PR DESCRIPTION
This PR tries to implement the switch to ms instead of `Duration` we discussed in #6.

Currently it doesn't compile, because `byte_program_duration()` and `page_program_duration()` return µs `Duration`s.
I don't know any easy way to solve this without effectively losing this feature.

It would probably be cleaner to use `embedded-time` for `no-std` instead. We would just need a way to abstract away the differences between `no-std` and `std` or use `embedded-time` in both cases.